### PR TITLE
feat: add conditional initialization of Prisma client based on NODE_ENV

### DIFF
--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -1,0 +1,14 @@
+import { PrismaClient } from "@prisma/client";
+
+let prisma: PrismaClient;
+
+if (process.env.NODE_ENV === "production") {
+  prisma = new PrismaClient();
+} else {
+  if (!global.prisma) {
+    global.prisma = new PrismaClient();
+  }
+  prisma = global.prisma;
+}
+
+export default prisma;


### PR DESCRIPTION
The Prisma client is now conditionally initialized based on the value of the NODE_ENV environment variable. In production, a new instance of the PrismaClient is created. In other environments, the PrismaClient instance is stored globally to ensure it is only initialized once.